### PR TITLE
feat(ci): Add docker-compose down command

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -54,6 +54,7 @@ jobs:
           username: ec2-user
           key: ${{ secrets.PEM_KEY }}
           script: |
+            sudo docker-compose down
             sudo docker rmi ${{ secrets.DOCKER_REPO }}/hometerview
-            docker-compose up -d
             docker image prune -f
+            docker-compose up -d


### PR DESCRIPTION
## 상세 내용
실행중인 도커 이미지를 제거하려고 시도하니, rmi 커맨드가 작동하지 않는 문제가 있었습니다.
따라서 docker-compose를 먼저 down 시키고 rmi 커맨드를 사용합니다.