### PR TITLE
Feature/auth

### DIFF
--- a/src/main/java/com/ftw/hometerview/auth/controller/AuthController.java
+++ b/src/main/java/com/ftw/hometerview/auth/controller/AuthController.java
@@ -2,16 +2,14 @@ package com.ftw.hometerview.auth.controller;
 
 import com.ftw.hometerview.auth.controller.dto.LoginRequest;
 import com.ftw.hometerview.auth.controller.dto.LoginResponse;
-import com.ftw.hometerview.auth.service.AuthService;
 import com.ftw.hometerview.auth.service.OAuthKakaoServiceImpl;
 import com.ftw.hometerview.core.annotation.NonAuthorized;
 import com.ftw.hometerview.core.domain.ResponseEntity;
+import com.ftw.hometerview.core.util.Constants;
 import io.swagger.v3.oas.annotations.Operation;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,21 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final OAuthKakaoServiceImpl oAuthKakaoServiceImpl;
-    private final AuthService authService;
 
     @Operation(summary = "카카오 token을 이용한 서버의 token 발급 받기")
     @NonAuthorized
     @PostMapping("/login/kakao")
-    public ResponseEntity<LoginResponse> kakaoLogin(@RequestBody LoginRequest loginRequest) {
-        var response = oAuthKakaoServiceImpl.login(loginRequest);
-        return ResponseEntity.successResponse(response);
-    }
-
-    @Operation(summary = "Refresh token을 이용한 Access token 갱신")
-    @NonAuthorized
-    @PostMapping("/refresh")
-    public ResponseEntity<Map<String, String>> refreshToken(HttpServletRequest request, @RequestBody String refreshToken) {
-        var response = authService.getNewAccessToken(request, refreshToken);
-        return ResponseEntity.successResponse(response);
+    public ResponseEntity kakaoLogin(HttpServletResponse response, @RequestBody LoginRequest loginRequest) {
+        LoginResponse result = oAuthKakaoServiceImpl.login(loginRequest);
+        response.setHeader(Constants.AUTH_ACCESS_HEADER_KEY, result.getAccessToken());
+        response.setHeader(Constants.AUTH_REFRESH_HEADER_KEY, result.getRefreshToken());
+        return ResponseEntity.successResponse();
     }
 }

--- a/src/main/java/com/ftw/hometerview/auth/controller/dto/LoginRequest.java
+++ b/src/main/java/com/ftw/hometerview/auth/controller/dto/LoginRequest.java
@@ -1,9 +1,7 @@
 package com.ftw.hometerview.auth.controller.dto;
 
-import lombok.Builder;
 import lombok.Getter;
 
-@Builder
 @Getter
 public class LoginRequest {
 

--- a/src/main/java/com/ftw/hometerview/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/ftw/hometerview/auth/util/JwtTokenProvider.java
@@ -78,14 +78,6 @@ public class JwtTokenProvider {
             .getSubject();
     }
 
-    public String resolveAccessToken(HttpServletRequest req) {
-        return req.getHeader(Constants.AUTH_ACCESS_HEADER_KEY);
-    }
-
-    public String resolveRefreshToken(HttpServletRequest req) {
-        return req.getHeader(Constants.AUTH_REFRESH_HEADER_KEY);
-    }
-
     public AuthContent getAuthentication(String memberId) {
         return AuthContent.builder().memberId(memberId).build();
     }

--- a/src/main/java/com/ftw/hometerview/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/ftw/hometerview/auth/util/JwtTokenProvider.java
@@ -3,7 +3,6 @@ package com.ftw.hometerview.auth.util;
 import com.ftw.hometerview.auth.util.vo.TokenData;
 import com.ftw.hometerview.auth.util.vo.TokenData.TokenStatus;
 import com.ftw.hometerview.core.interceptor.AuthContent;
-import com.ftw.hometerview.core.util.Constants;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -12,7 +11,6 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Random;
-import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/ftw/hometerview/auth/util/vo/TokenData.java
+++ b/src/main/java/com/ftw/hometerview/auth/util/vo/TokenData.java
@@ -1,0 +1,16 @@
+package com.ftw.hometerview.auth.util.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class TokenData {
+    public enum TokenStatus {
+        EXPIRED, INVALID, VALID;
+    }
+
+    TokenStatus tokenStatus;
+
+    String payload;
+}

--- a/src/main/java/com/ftw/hometerview/core/config/SwaggerConfig.java
+++ b/src/main/java/com/ftw/hometerview/core/config/SwaggerConfig.java
@@ -13,6 +13,7 @@ import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.ApiKey;
 import springfox.documentation.service.AuthorizationScope;
 import springfox.documentation.service.SecurityReference;
+import springfox.documentation.service.SecurityScheme;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
@@ -25,7 +26,7 @@ public class SwaggerConfig {
     public Docket api() {
         return new Docket(DocumentationType.OAS_30)
             .apiInfo(apiInfo())
-            .securitySchemes(List.of(apiKey()))
+            .securitySchemes(apiKey())
             .securityContexts(List.of(securityContext()))
             .useDefaultResponseMessages(false)
             .groupName("hometerview-server")
@@ -43,8 +44,11 @@ public class SwaggerConfig {
             .build();
     }
 
-    private ApiKey apiKey() {
-        return new ApiKey(Constants.AUTH_HEADER_KEY, "JWT", "header");
+    private List<SecurityScheme> apiKey() {
+        return List.of(
+            new ApiKey(Constants.AUTH_ACCESS_HEADER_KEY, "JWT_ACCESS", "header"),
+            new ApiKey(Constants.AUTH_REFRESH_HEADER_KEY, "JWT_REFRESH", "header")
+        );
     }
 
     private SecurityContext securityContext() {
@@ -57,7 +61,10 @@ public class SwaggerConfig {
         AuthorizationScope authorizationScope = new AuthorizationScope("global",
             "accessEverything");
         AuthorizationScope[] authorizationScopes = new AuthorizationScope[]{authorizationScope};
-        return List.of(new SecurityReference(Constants.AUTH_HEADER_KEY, authorizationScopes));
+        return List.of(
+            new SecurityReference(Constants.AUTH_ACCESS_HEADER_KEY, authorizationScopes),
+            new SecurityReference(Constants.AUTH_REFRESH_HEADER_KEY, authorizationScopes)
+        );
     }
 
 }

--- a/src/main/java/com/ftw/hometerview/core/config/WebConfig.java
+++ b/src/main/java/com/ftw/hometerview/core/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.ftw.hometerview.core.config;
 
+import com.ftw.hometerview.auth.service.AuthService;
 import com.ftw.hometerview.auth.util.JwtTokenProvider;
 import com.ftw.hometerview.core.interceptor.AuthorizationInterceptor;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +16,11 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    private final AuthService authService;
+
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AuthorizationInterceptor(jwtTokenProvider))
+        registry.addInterceptor(new AuthorizationInterceptor(jwtTokenProvider, authService))
             .addPathPatterns("/api/**");
     }
 }

--- a/src/main/java/com/ftw/hometerview/core/domain/ResponseType.java
+++ b/src/main/java/com/ftw/hometerview/core/domain/ResponseType.java
@@ -21,16 +21,15 @@ public enum ResponseType {
     JWT_SIGNATURE("CM07", "시그니처 검증에 실패한 토큰입니다."),
     JWT_EXPIRED("CM08", "만료된 토큰입니다."),
     JWT_NULL_OR_EMPTY("CM09", "토큰이 없거나 값이 비어있습니다."),
-    JWT_HEADER_PREFIX("CM10", "토큰 값은 " + Constants.AUTH_HEADER_KEY + " 로 시작해야 합니다."),
+    JWT_HEADER_PREFIX("CM10", "토큰 값은 " + Constants.AUTH_ACCESS_HEADER_KEY + " 로 시작해야 합니다."),
 
     // AUTH
     AUTH_NULL_TOKEN("AU01", "토큰을 찾을 수 없습니다."),
     AUTH_NOT_SAME_TOKEN("AU02", "저장된 토큰과 일치하지 않습니다."),
     AUTH_NOT_SAME_USER("AU03", "Access와 Refresh 토큰의 사용자가 일치하지 않습니다."),
-    AUTH_NOT_FOUND_REDIS_KEY("AU04", "Redis에서 해당 Key를 찾을 수 없습니다."),
-    AUTH_NOT_FOUND_COOKIE_KEY("AU05", "Cookie에서 해당 Key를 찾을 수 없습니다."),
     AUTH_NOT_SUPPORT_PROVIDER("AU06", "지원하지 않는 Provider입니다."),
     AUTH_NOT_MATCH_PROVIDER("AU07", "가입된 OAuth 제공자와 일치하지 않습니다."),
+    AUTH_REQUIRE_LOGIN("AU08", "재로그인이 필요합니다."),
 
     // MEMBER
     MEMBER_NOT_EXIST_ID("ME01", "존재하지 않는 사용자입니다."),

--- a/src/main/java/com/ftw/hometerview/core/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/ftw/hometerview/core/interceptor/AuthorizationInterceptor.java
@@ -6,6 +6,7 @@ import com.ftw.hometerview.auth.util.vo.TokenData;
 import com.ftw.hometerview.core.annotation.NonAuthorized;
 import com.ftw.hometerview.core.domain.ResponseType;
 import com.ftw.hometerview.core.exception.UnauthorizedException;
+import com.ftw.hometerview.core.util.Constants;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -41,8 +42,8 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
     }
 
     private void tokenAuthorize(HttpServletRequest request, HttpServletResponse response) {
-        String accessToken = jwtTokenProvider.resolveAccessToken(request);
-        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+        String accessToken = request.getHeader(Constants.AUTH_ACCESS_HEADER_KEY);
+        String refreshToken =  request.getHeader(Constants.AUTH_REFRESH_HEADER_KEY);
 
         if (!StringUtils.hasText(accessToken) || !StringUtils.hasText(refreshToken)) {
             throw new UnauthorizedException(ResponseType.REQUEST_UNAUTHORIZED);

--- a/src/main/java/com/ftw/hometerview/core/util/Constants.java
+++ b/src/main/java/com/ftw/hometerview/core/util/Constants.java
@@ -2,7 +2,8 @@ package com.ftw.hometerview.core.util;
 
 public class Constants {
 
-    public static final String AUTH_HEADER_KEY = "Authorization";
+    public static final String AUTH_ACCESS_HEADER_KEY = "Authorization-Access-Token";
+    public static final String AUTH_REFRESH_HEADER_KEY = "Authorization-Refresh-Token";
     public static final int DEFAULT_PAGE_SIZE = 5;
     public static final String DEFAULT_KEYWORD = ".*";   // mongo wildcard
 

--- a/src/main/java/com/ftw/hometerview/member/domain/Member.java
+++ b/src/main/java/com/ftw/hometerview/member/domain/Member.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.FieldType;
 import org.springframework.data.mongodb.core.mapping.MongoId;
 
 @Builder
@@ -15,7 +16,7 @@ import org.springframework.data.mongodb.core.mapping.MongoId;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Member extends AbstractDocument {
 
-    @MongoId
+    @MongoId(FieldType.OBJECT_ID)
     String id;
 
     String memberId;

--- a/src/main/resources/application-sample.yml
+++ b/src/main/resources/application-sample.yml
@@ -1,0 +1,30 @@
+spring:
+  data:
+    mongodb:
+      uri:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id:
+            authorization-grant-type:
+            scope:
+            client-name:
+            client-authentication-method:
+            redirect-uri:
+
+jwt:
+  token:
+    secret-key:
+  access-token:
+    expire-length:
+  refresh-token:
+    expire-length:
+oauth2:
+  apple:
+    authUrl:
+    url:
+    teamId:
+    keyId:
+    clientId:


### PR DESCRIPTION
## 상세 내용
> 인증 로직을 수정하였습니다.
### 변경 전
`Refresh token`을 이용한 `Access token` reissue는 엔드포인트를 통해 직접 요청해야만 가능했습니다.

### 변경 후

**추가**
- 인증이 필요한 요청을 보낼 시 Header에 `Access token`과 `Refresth token`을 포함시켜야 합니다.
- `Access token` 갱신을 위해서 엔드포인트를 통해 요청할 필요 없이 만료되면 자동으로 갱신하여 응답 헤더에 새로운 `Access token`을 보냅니다.
- 헤더 인증 필드 추가에 따라 Swagger-ui에서도 `Refresh token`을 설정할 수 있도록 입력 필드를 추가하였습니다.
- applicaiton 정상 동작을 위한 샘플 yml 파일을 추가하였습니다. (값은 비어있습니다)

**버그 픽스**
- 간헐적으로 ObjectId 형태가 아닌 String 형태로 멤버가 저장되던 버그를 수정하였습니다.


## Checklist
### 내용
- [x] 기술 용어를 통일했는가? - 영어, 한글 혼용 여부
- [x] 레퍼런스 형식을 통일했는가? - 레퍼런스는 글 마지막에 리스트 형식으로 작성
- [x] 글이 주제에 맞는 흐름으로 진행되었는가?
- [x] 태그가 올바르게 달려있는가?
- [x] 모든 리소스들에 대해 출처를 작성했는가?
### 코드
- [x] 중복된 코드는 없는가?
- [x] 모호한 네이밍은 없는가? - 있다면 PR에서 논의 바람
- [x] 로컬에서 테스트를 진행하고 이상 없음을 확인했는가?
