### PR TITLE
refactor: loadname -> roadname으로 변경 및 Station 도메인 수정

### DIFF
--- a/src/main/java/com/ftw/hometerview/core/util/Constants.java
+++ b/src/main/java/com/ftw/hometerview/core/util/Constants.java
@@ -8,7 +8,7 @@ public class Constants {
     public static final String DEFAULT_KEYWORD = ".*";   // mongo wildcard
 
     public static final String NAME = "name";
-    public static final String LOAD_NAME = "loadName";
+    public static final String ROAD_ADDRESS = "roadAddress";
     public static final String STATION = "station";
 
 }

--- a/src/main/java/com/ftw/hometerview/place/controller/dto/BuildingDto.java
+++ b/src/main/java/com/ftw/hometerview/place/controller/dto/BuildingDto.java
@@ -12,7 +12,7 @@ public class BuildingDto {
 
         private String buildingId;
         private String name;
-        private String loadName;
+        private String roadAddress;
     }
 
     @Getter
@@ -21,7 +21,7 @@ public class BuildingDto {
 
         private String buildingId;
         private String name;
-        private String loadName;
+        private String roadAddress;
         private ResidenceType residenceType;
         private Integer totalRating;
 

--- a/src/main/java/com/ftw/hometerview/place/controller/dto/CompanyDto.java
+++ b/src/main/java/com/ftw/hometerview/place/controller/dto/CompanyDto.java
@@ -14,7 +14,7 @@ public class CompanyDto {
         @NotBlank
         private String name;
         @NotBlank
-        private String loadName;
+        private String roadAddress;
         @NotNull
         private Double lat;
         @NotNull
@@ -23,8 +23,8 @@ public class CompanyDto {
         public Company toCompany() {
             return Company.builder()
                 .name(this.name)
-                .loadName(this.loadName)     // oo시 oo구 oo동 ~~
-                .province(this.loadName.split(" ")[1])
+                .roadAddress(this.roadAddress)     // oo시 oo구 oo동 ~~
+                .province(this.roadAddress.split(" ")[1])
                 .lat(this.lat)
                 .lon(this.lon)
                 .build();
@@ -37,7 +37,7 @@ public class CompanyDto {
 
         private String companyId;
         private String name;
-        private String loadName;
+        private String roadAddress;
         private String nearestStation;
 
         public void setStationName(String stationName) {

--- a/src/main/java/com/ftw/hometerview/place/controller/dto/StationDto.java
+++ b/src/main/java/com/ftw/hometerview/place/controller/dto/StationDto.java
@@ -10,8 +10,12 @@ public class StationDto {
     public static class Meta {
 
         private String stationId;
+        private String lineNumber;
         private String name;
-        private String loadName;
+        private String lotNumberAddress;
+        private String roadAddress;
+        private Double lat;
+        private Double lon;
     }
 
 }

--- a/src/main/java/com/ftw/hometerview/place/domain/Building.java
+++ b/src/main/java/com/ftw/hometerview/place/domain/Building.java
@@ -22,7 +22,7 @@ public class Building extends AbstractDocument {
     String id;
 
     String name;
-    String loadName;
+    String roadAddress;
     String city;
     Double lat;
     Double lon;
@@ -39,7 +39,7 @@ public class Building extends AbstractDocument {
         return BuildingDto.Meta.builder()
             .buildingId(this.id)
             .name(this.name)
-            .loadName(this.loadName)
+            .roadAddress(this.roadAddress)
             .build();
     }
 }

--- a/src/main/java/com/ftw/hometerview/place/domain/Company.java
+++ b/src/main/java/com/ftw/hometerview/place/domain/Company.java
@@ -20,7 +20,7 @@ public class Company extends AbstractDocument {
     String id;
 
     String name;
-    String loadName;
+    String roadAddress;
     String province;
     String stationId;
     Double lat;
@@ -35,7 +35,7 @@ public class Company extends AbstractDocument {
         return CompanyDto.Meta.builder()
             .companyId(this.id)
             .name(this.name)
-            .loadName(this.loadName)
+            .roadAddress(this.roadAddress)
             .build();
     }
 

--- a/src/main/java/com/ftw/hometerview/place/domain/Station.java
+++ b/src/main/java/com/ftw/hometerview/place/domain/Station.java
@@ -18,17 +18,23 @@ public class Station extends AbstractDocument {
 
     @MongoId(FieldType.OBJECT_ID)
     String id;
+    String lineNumber;
     String name;
-    String loadName;
+    String lotNumberAddress;
+    String roadAddress;
     Double lat;
     Double lon;
 
     public StationDto.Meta toMeta() {
         return StationDto.Meta.builder()
-            .stationId(this.id)
-            .name(this.name)
-            .loadName(this.loadName)
-            .build();
+                .stationId(this.id)
+                .lineNumber(this.lineNumber)
+                .name(this.name)
+                .lotNumberAddress(this.lotNumberAddress)
+                .roadAddress(this.roadAddress)
+                .lat(this.lat)
+                .lon(this.lon)
+                .build();
     }
 
 }

--- a/src/main/java/com/ftw/hometerview/place/repository/building/BuildingRepositoryImpl.java
+++ b/src/main/java/com/ftw/hometerview/place/repository/building/BuildingRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.ftw.hometerview.place.repository.building;
 
-import static com.ftw.hometerview.core.util.Constants.LOAD_NAME;
+import static com.ftw.hometerview.core.util.Constants.ROAD_ADDRESS;
 import static com.ftw.hometerview.core.util.Constants.NAME;
 
 import com.ftw.hometerview.place.domain.Building;
@@ -20,7 +20,7 @@ public class BuildingRepositoryImpl implements BuildingRepositoryCustom {
     public List<Building> searchByKeyword(String keyword, Pageable pageable) {
         Criteria criteria = new Criteria().orOperator(
             Criteria.where(NAME).regex(keyword, "i"),
-            Criteria.where(LOAD_NAME).regex(keyword, "i")
+            Criteria.where(ROAD_ADDRESS).regex(keyword, "i")
         );
 
         return mongoTemplate.find(Query.query(criteria).with(pageable), Building.class);

--- a/src/main/java/com/ftw/hometerview/place/repository/company/CompanyRepositoryCustom.java
+++ b/src/main/java/com/ftw/hometerview/place/repository/company/CompanyRepositoryCustom.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Pageable;
 public interface CompanyRepositoryCustom {
 
     List<Company> searchByKeyword(String keyword, Pageable pageable);
-    boolean existsByNameAndLoadName(String name, String loadName);
+    boolean existsByNameAndRoadAddress(String name, String roadAddress);
 
 }

--- a/src/main/java/com/ftw/hometerview/place/repository/company/CompanyRepositoryImpl.java
+++ b/src/main/java/com/ftw/hometerview/place/repository/company/CompanyRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.ftw.hometerview.place.repository.company;
 
-import static com.ftw.hometerview.core.util.Constants.LOAD_NAME;
+import static com.ftw.hometerview.core.util.Constants.ROAD_ADDRESS;
 import static com.ftw.hometerview.core.util.Constants.NAME;
 import static com.ftw.hometerview.core.util.Constants.STATION;
 
@@ -21,7 +21,7 @@ public class CompanyRepositoryImpl implements CompanyRepositoryCustom {
     public List<Company> searchByKeyword(String keyword, Pageable pageable) {
         Criteria criteria = new Criteria().orOperator(
             Criteria.where(NAME).regex(keyword, "i"),
-            Criteria.where(LOAD_NAME).regex(keyword, "i"),
+            Criteria.where(ROAD_ADDRESS).regex(keyword, "i"),
             Criteria.where(STATION).regex(keyword, "i")
         );
 
@@ -29,8 +29,8 @@ public class CompanyRepositoryImpl implements CompanyRepositoryCustom {
     }
 
     @Override
-    public boolean existsByNameAndLoadName(String name, String loadName) {
-        Criteria criteria = Criteria.where(NAME).is(name).and(LOAD_NAME).is(loadName);
+    public boolean existsByNameAndRoadAddress(String name, String roadAddress) {
+        Criteria criteria = Criteria.where(NAME).is(name).and(ROAD_ADDRESS).is(roadAddress);
         return mongoTemplate.exists(Query.query(criteria), Company.class);
     }
 

--- a/src/main/java/com/ftw/hometerview/place/repository/station/StationRepositoryImpl.java
+++ b/src/main/java/com/ftw/hometerview/place/repository/station/StationRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.ftw.hometerview.place.repository.station;
 
-import static com.ftw.hometerview.core.util.Constants.LOAD_NAME;
+import static com.ftw.hometerview.core.util.Constants.ROAD_ADDRESS;
 import static com.ftw.hometerview.core.util.Constants.NAME;
 
 import com.ftw.hometerview.place.domain.Station;
@@ -20,7 +20,7 @@ public class StationRepositoryImpl implements StationRepositoryCustom {
     public List<Station> searchByKeyword(String keyword, Pageable pageable) {
         Criteria criteria = new Criteria().orOperator(
             Criteria.where(NAME).regex(keyword, "i"),
-            Criteria.where(LOAD_NAME).regex(keyword, "i")
+            Criteria.where(ROAD_ADDRESS).regex(keyword, "i")
         );
 
         return mongoTemplate.find(Query.query(criteria).with(pageable), Station.class);

--- a/src/main/java/com/ftw/hometerview/place/service/CompanyService.java
+++ b/src/main/java/com/ftw/hometerview/place/service/CompanyService.java
@@ -17,7 +17,7 @@ public class CompanyService {
     private final CompanyRepository companyRepository;
 
     public void register(CompanyDto.RegisterCompany req) {
-        if (isDuplicated(req.getName(), req.getLoadName())) {
+        if (isDuplicated(req.getName(), req.getRoadAddress())) {
             throw new BadRequestException(ResponseType.DATA_DUPLICATED);
         }
         Company company = req.toCompany();
@@ -27,8 +27,8 @@ public class CompanyService {
         this.companyRepository.save(company);
     }
 
-    private boolean isDuplicated(String name, String loadName) {
-        return this.companyRepository.existsByNameAndLoadName(name, loadName);
+    private boolean isDuplicated(String name, String roadAddress) {
+        return this.companyRepository.existsByNameAndRoadAddress(name, roadAddress);
     }
 
     public List<CompanyDto.Meta> searchByKeyword(String keyword, Pageable pageable) {


### PR DESCRIPTION
## 상세 내용
- 오타로 인해 `loadname`에서 `roadAddress`으로 일괄 변경
  - `도로명`(roadName) -> `도로명주소`(roadAddress)라는 명칭으로 변경했으며 이 경우 `roadAddress`로 명확한 단어를 사용하여 추후 Client에서 혼선이 없도록 하기 위함
- 역 도메인에 위/경도, 지번 주소 추가  
  ![image](https://user-images.githubusercontent.com/47562093/214319369-d735bee5-84e6-4bab-95c7-a252c24483ca.png)
  - 각 역 데이터는 지도에서 `위/경도` 데이터를 통해 마커 표시를 하므로 필요한 데이터
  - `지번 주소`의 경우 도로명 주소로 검색이 되지 않는 경우가 있음 (예. 지하 3 같은 부가적인 정보가 붙을 때 검색 안됨)

## Checklist
### 내용
- [x] 기술 용어를 통일했는가? - 영어, 한글 혼용 여부
- [x] 레퍼런스 형식을 통일했는가? - 레퍼런스는 글 마지막에 리스트 형식으로 작성
- [x] 글이 주제에 맞는 흐름으로 진행되었는가?
- [x] 태그가 올바르게 달려있는가?
- [x] 모든 리소스들에 대해 출처를 작성했는가?
### 코드
- [x] 중복된 코드는 없는가?
- [x] 모호한 네이밍은 없는가? - 있다면 PR에서 논의 바람
- [x] 로컬에서 테스트를 진행하고 이상 없음을 확인했는가?
